### PR TITLE
feat: スマホでのギャラリーコンパクト表示を3列組に変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -537,7 +537,7 @@
             }
             
             .thumbnails-grid.compact {
-                grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+                grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
             }
             
             .modal-nav {


### PR DESCRIPTION
スマホでのギャラリー表示を2列組から3列組に変更しました。

## 変更内容
- モバイル表示のcompactビューで`minmax(150px, 1fr)`を`minmax(100px, 1fr)`に変更
- より狭い画面でも3列表示が可能になります
- デスクトップ表示は従来通り変更されていません

Fixes #4

Generated with [Claude Code](https://claude.ai/code)