### PR TITLE
feat: アイコンの横にタイトル「tomoπxel」を追加

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -577,6 +577,7 @@
         <div class="nav-container">
             <div class="logo">
                 <div class="pixel-bird"></div>
+                tomoπxel
             </div>
             <nav class="nav-links">
                 <a href="#" class="nav-link active" data-view="random">Home</a>


### PR DESCRIPTION
Fixes #6

アイコン（浮いている多面体）の横の空のタイトル欄に「tomoπxel」を追加しました。

Generated with [Claude Code](https://claude.ai/code)